### PR TITLE
[SSM-3149] Change multpart_file_upload.rb to use import_mosaic

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ There are four basic steps for uploading a file in multiple parts, and then usin
 Full documentation of this workflow can be found [here](https://api.sentera.com/api/getting_started/uploading_files.html)
 
 ## Examples
-| Language | Run Command                       |
-| :------- | :---------------------------------|
-| Ruby     | `$ ruby file_upload.rb`           |
-| Ruby     | `$ ruby multipart_file_upload.rb` |
+| Language | Run Command                       | Example Command |
+| :------- | :---------------------------------|-----------------|
+| Ruby     | `$ ruby file_upload.rb`           | `FIELDAGENT_ACCESS_TOKEN=AKgnGiLNpk1AjppMqWSWbiNMNUYepcP8EalLo_gYRpM FIELDAGENT_SERVER=https://api.sentera.com OWNER_TYPE=SURVEY OWNER_SENTERA_ID=9nfdf02_CO_ytwfAcmeOrg_CV_deve_c49295f37_230411_080321 ruby file_upload.rb` |
+| Ruby     | `$ ruby multipart_file_upload.rb` | `FIELDAGENT_ACCESS_TOKEN=AKgnGiLNpk1AjppMqWSWbiNMNUYepcP8EalLo_gYRpM FIELDAGENT_SERVER=https://api.sentera.com PARENT_SENTERA_ID=9nfdf02_CO_ytwfAcmeOrg_CV_deve_c49295f37_230411_080321 ruby multipart_file_upload.rb` |

--- a/file_upload.rb
+++ b/file_upload.rb
@@ -181,7 +181,7 @@ file_id = results['id']
 upload_file(upload_url, upload_headers, file_path)
 
 # Step 3: Use the file with FieldAgent
-results = use_file(file_id, owner_type, owner_sentera_id)
+results = import_feature_set(file_id, owner_type, owner_sentera_id)
 
 if results
   puts "Done! File #{file_path} was successfully imported to a feature set attached to #{owner_type} #{owner_sentera_id}."

--- a/file_upload.rb
+++ b/file_upload.rb
@@ -110,33 +110,36 @@ end
 # was previously uploaded to Sentera's cloud storage with one
 # of the mutations in Sentera's GraphQL API that accepts a
 # file ID as an input. In this example, we'll use the
-# import_files GraphQL mutation, and attach the file to
-# a file owner that belongs to the caller's FieldAgent organization.
+# import_feature_set GraphQL mutation to attach the file to
+# a feature set owned by the specified file owner
 #
 # @param [string] file_id ID of the uploaded file
-# @param [string] file_owner_type Type of file owner to create. For example,
-#                                 FEATURE_SET, MOSAIC, etc.
-# @param [string] file_owner_sentera_id Sentera ID of the resource
-#                                       (field, survey, feature set, etc.)
-#                                       to which the file should be attached.
+# @param [string] owner_type Type of owner that will own the
+#                            feature set. For example: SURVEY.
+# @param [string] owner_sentera_id Sentera ID of the resource
+#                           (field, survey, feature set, etc.)
+#                           that will own the feature set that
+#                           is created.
 #
 # @return [Hash] Hash containing results of the GraphQL request
 #
-def use_file(file_id, file_owner_type, file_owner_sentera_id)
+def use_file(file_id, owner_type, owner_sentera_id)
   puts 'Use file'
 
   gql = <<~GQL
-    mutation ImportFiles(
-      $file_keys: [String!]!
-      $file_type: FileType!
+    mutation ImportFeatureSet(
+      $geometry_file_key: FileKey
+      $name: String!
       $owner_sentera_id: ID!
-      $owner_type: FileOwnerType!
+      $owner_type: FeatureSetOwnerType!
+      $type: FeatureSetType!
     ) {
-      import_files(
-        owner_type: $owner_type
+      import_feature_set(
+        geometry_file_key: $geometry_file_key
+        name: $name
         owner_sentera_id: $owner_sentera_id
-        file_type: $file_type
-        file_keys: $file_keys
+        owner_type: $owner_type
+        type: $type
       ) {
         status
       }
@@ -144,15 +147,16 @@ def use_file(file_id, file_owner_type, file_owner_sentera_id)
   GQL
 
   variables = {
-    owner_type: file_owner_type,
-    owner_sentera_id: file_owner_sentera_id,
-    file_type: 'FLIGHT_LOG',
-    file_keys: [file_id]
+    geometry_file_key: file_id,
+    name: 'Test Feature Set',
+    owner_sentera_id: owner_sentera_id,
+    owner_type: owner_type,
+    type: 'UNKNOWN'
   }
 
   response = make_graphql_request(gql, variables)
   json = JSON.parse(response.body)
-  json.dig('data', 'import_files')
+  json.dig('data', 'import_feature_set')
 end
 
 # MAIN
@@ -161,10 +165,10 @@ end
 # Set these variables based on the file you want to
 # upload and the resource within FieldAgent to which
 # you wish to attach the file.
-file_path = 'test.geojson' # Your fully qualified file path goes here
-content_type = 'application/json' # Your MIME content type goes here
-file_owner_type = 'FEATURE_SET' # Your file owner type goes here
-file_owner_sentera_id = 'sezjmpa_FS_arpmAcmeOrg_CV_deve_b822f1701_230330_110124' # Your file owner Sentera ID goes here
+file_path = ENV.fetch('FILE_PATH', 'test.geojson') # Your fully qualified file path
+content_type = ENV.fetch('CONTENT_TYPE', 'application/json') # Your MIME content type
+owner_type = ENV.fetch('OWNER_TYPE', 'SURVEY') # Your owner type
+owner_sentera_id = ENV.fetch('OWNER_SENTERA_ID', 'sezjmpa_CO_arpmAcmeOrg_CV_deve_b822f1701_230330_110124') # Your owner Sentera ID
 # **************************************************
 
 # Step 1: Create a file upload
@@ -177,10 +181,10 @@ file_id = results['id']
 upload_file(upload_url, upload_headers, file_path)
 
 # Step 3: Use the file with FieldAgent
-results = use_file(file_id, file_owner_type, file_owner_sentera_id)
+results = use_file(file_id, owner_type, owner_sentera_id)
 
 if results
-  puts "Done! File #{file_path} was successfully uploaded and attached to #{file_owner_type} #{file_owner_sentera_id}."
+  puts "Done! File #{file_path} was successfully imported to a feature set attached to #{owner_type} #{owner_sentera_id}."
 else
   puts 'Failed'
 end

--- a/file_upload.rb
+++ b/file_upload.rb
@@ -123,7 +123,7 @@ end
 #
 # @return [Hash] Hash containing results of the GraphQL request
 #
-def use_file(file_id, owner_type, owner_sentera_id)
+def import_feature_set(file_id, owner_type, owner_sentera_id)
   puts 'Use file'
 
   gql = <<~GQL

--- a/multipart_file_upload.rb
+++ b/multipart_file_upload.rb
@@ -245,36 +245,40 @@ end
 # was previously uploaded to Sentera's cloud storage with one
 # of the mutations in Sentera's GraphQL API that accepts a
 # file ID as an input. In this example, we'll use the
-# import_files GraphQL mutation, and attach the file to
-# a feature set that the caller is permitted to access.
+# import_mosaic GraphQL mutation to attach the file to
+# the mosaic created in step 1.
 #
+# @param [string] owner_sentera_id Sentera ID of the resource in
+#                                  FieldAgent to which the file should
+#                                  be attached.
+# @param [string] parent_sentera_id Sentera ID of the resource in
+#                                   FieldAgent that will is the parent
+#                                   of the owner.
 # @param [string] file_id ID of the uploaded file
-# @param [string] file_owner_type Type of file owner to create. For example,
-#                                 FEATURE_SET, MOSAIC, etc.
-# @param [string] file_owner_sentera_id Sentera ID of the resource
-#                                       (field, survey, feature set, etc.)
-#                                       to which the file should be attached.
-# @param [string] file_path Fully qualified path to file that was uploaded
 #
 # @return [Hash] Hash containing results of the GraphQL request
 #
-def use_file(file_id, file_owner_type, file_owner_sentera_id, file_path)
+def use_file(owner_sentera_id, parent_sentera_id, file_id)
   puts 'Use file'
 
-  path = File.dirname(file_path)
-  filename = File.basename(file_path)
-  byte_size = File.size(file_path)
-
   gql = <<~GQL
-    mutation UpsertFiles(
-      $files: [FileImport!]!
-      $owner: FileOwnerInput!
+    mutation ImportMosaic(
+      $file_keys: [FileKey!]
+      $mosaic_sentera_id: ID
+      $mosaic_type: MosaicImportType!
+      $name: String!
+      $quality: MosaicQuality!
+      $survey_sentera_id: ID
     ) {
-      upsert_files(
-        owner: $owner
-        files: $files
-      ) {
-        succeeded {
+      import_mosaic(
+        file_keys: $file_keys
+        mosaic_sentera_id: $mosaic_sentera_id
+        mosaic_type: $mosaic_type
+        name: $name
+        quality: $quality
+        survey_sentera_id: $survey_sentera_id
+        ) {
+        survey {
           sentera_id
         }
       }
@@ -282,24 +286,17 @@ def use_file(file_id, file_owner_type, file_owner_sentera_id, file_path)
   GQL
 
   variables = {
-    owner: {
-      owner_type: file_owner_type,
-      sentera_id: file_owner_sentera_id
-    },
-    files: [
-      {
-        file_type: file_owner_type,
-        filename: filename,
-        path: path,
-        size: byte_size,
-        version: 1
-      }
-    ]
+    file_keys: [file_id],
+    mosaic_sentera_id: owner_sentera_id,
+    mosaic_type: 'RGB',
+    name: 'Test Mosaic',
+    quality: 'FULL',
+    survey_sentera_id: parent_sentera_id
   }
 
   response = make_graphql_request(gql, variables)
   json = JSON.parse(response.body)
-  json.dig('data', 'upsert_files')
+  json.dig('data', 'import_mosaic')
 end
 
 # MAIN
@@ -308,20 +305,20 @@ end
 # Set these variables based on the file you want to
 # upload and the resource within FieldAgent to which
 # you wish to attach the file.
-file_path = 'test.tif' # Your fully qualified file path goes here
-content_type = 'image/tiff' # Your MIME content type goes here'
-parent_sentera_id = 'llzwked_CO_arpmAcmeOrg_CV_deve_b822f1701_230330_110124' # Your parent Sentera ID goes here
-file_owner_type = 'MOSAIC' # Your file owner type goes here
+file_path = ENV.fetch('FILE_PATH', 'test.tif') # Your fully qualified file path
+content_type = ENV.fetch('CONTENT_TYPE', 'image/tiff') # Your MIME content type
+parent_sentera_id = ENV.fetch('PARENT_SENTERA_ID', 'llzwked_CO_arpmAcmeOrg_CV_deve_b822f1701_230330_110124') # Your parent Sentera ID
+owner_type = ENV.fetch('OWNER_TYPE', 'MOSAIC') # Your owner type
 # **************************************************
 
 # Step 1: Create a multipart file upload
-results = create_multipart_file_upload(file_path, content_type, parent_sentera_id, file_owner_type)
+results = create_multipart_file_upload(file_path, content_type, parent_sentera_id, owner_type)
 if results.nil?
   puts 'Failed'
   exit
 end
 file_id = results['file_id']
-file_owner_sentera_id = results['owner_sentera_id']
+owner_sentera_id = results['owner_sentera_id']
 s3_key = results['s3_key']
 upload_id = results['upload_id']
 
@@ -332,10 +329,10 @@ parts = upload_file(file_path, s3_key, upload_id)
 complete_multipart_file_upload(parts, s3_key, upload_id)
 
 # Step 4: Use the file with Sentera FieldAgent
-results = use_file(file_id, file_owner_type, file_owner_sentera_id, file_path)
+results = use_file(owner_sentera_id, parent_sentera_id, file_id)
 
 if results
-  puts "Done! File #{file_path} was successfully uploaded and attached to #{file_owner_type} #{file_owner_sentera_id}."
+  puts "Done! File #{file_path} was successfully uploaded and imported to #{owner_type} #{owner_sentera_id}."
 else
   puts 'Failed'
 end

--- a/multipart_file_upload.rb
+++ b/multipart_file_upload.rb
@@ -329,7 +329,7 @@ parts = upload_file(file_path, s3_key, upload_id)
 complete_multipart_file_upload(parts, s3_key, upload_id)
 
 # Step 4: Use the file with Sentera FieldAgent
-results = use_file(owner_sentera_id, parent_sentera_id, file_id)
+results = import_mosaic(owner_sentera_id, parent_sentera_id, file_id)
 
 if results
   puts "Done! File #{file_path} was successfully uploaded and imported to #{owner_type} #{owner_sentera_id}."

--- a/multipart_file_upload.rb
+++ b/multipart_file_upload.rb
@@ -258,7 +258,7 @@ end
 #
 # @return [Hash] Hash containing results of the GraphQL request
 #
-def use_file(owner_sentera_id, parent_sentera_id, file_id)
+def import_mosaic(owner_sentera_id, parent_sentera_id, file_id)
   puts 'Use file'
 
   gql = <<~GQL


### PR DESCRIPTION
## Why?
The `import_mosaic` GQL mutation is a better mutation to use to illustrate the multipart file upload workflow because it is the recommended way to import `.tif` files into FieldAgent.

## What
* Updates `multipart_file_upload.rb` to use `import_mosaic` to upload a `.tif` and import it into FieldAgent as a mosaic.
* Updates `multipart_file_upload.rb` to use environment variables for the input variables. This allows someone to run the script without having to modify it.
* Updates `file_upload.rb` to  use  `import_feature_set` to upload a GeoJSON file and import it into FieldAgent as a feature set.
* Updates `file_upload.rb` to use environment variables for the input variables. This allows someone to run the script without having to modify it.

### Screenshot(s)

### JIRA Link
https://sentera.atlassian.net/browse/SSM-3149

## QA Strategy
- [ ] Merge Latest Master
- [ ] Regression Test?
- [ ] Test New Feature?
